### PR TITLE
Remove IppResponseError to fix IppResponseError is not a constructor

### DIFF
--- a/lib/request.js
+++ b/lib/request.js
@@ -7,16 +7,6 @@ const url = require('url');
 const isReadableStream = require('./isReadableStream');
 const parse = require('./parser');
 
-const IppResponseError = (statusCode, message) => {
-  this.name = 'IppResponseError';
-  this.statusCode = statusCode;
-  this.message = message || `Received unexpected response status ${statusCode} from the printer`;
-  this.stack = new Error().stack;
-};
-
-IppResponseError.prototype = Object.create(Error.prototype);
-IppResponseError.prototype.constructor = IppResponseError;
-
 const readResponse = (res, cb) => {
   const chunks = [];
   let length = 0;
@@ -69,7 +59,7 @@ const request = (opts, buffer, cb) => {
     switch (res.statusCode) {
       case 100:
         if (opts.headers.Expect !== '100-Continue' || typeof opts.continue !== 'function') {
-          cb(new IppResponseError(res.statusCode));
+          cb(new Error(`Received unexpected response status ${res.statusCode} from the printer.`));
         }
 
         // console.log('100 Continue');
@@ -78,7 +68,7 @@ const request = (opts, buffer, cb) => {
         return readResponse(res, cb);
       default:
         // console.log(res.statusCode, 'response');
-        cb(new IppResponseError(res.statusCode));
+        cb(new Error(`Received unexpected response status ${res.statusCode} from the printer.`));
     }
   });
 


### PR DESCRIPTION
This fix an error "'IppResponseError is not a constructor" when a HTTP reverse proxy responds 404 without any IPP data. Remove the IppResponseError code for now.

Uncaught exception occurred. Terminate process. (fatal)

17:59:42.840@2018-05-07 48425#5
{
  name: 'TypeError',
  message: 'IppResponseError is not a constructor',
  stack: 'TypeError: IppResponseError is not a constructor
    at ClientRequest.req.request (/Users/stefan/code/plossys/xxx/node_modules/@sealsystems/ipp/lib/request.js:79:12)
    at Object.onceWrapper (events.js:315:30)
    at emitOne (events.js:116:13)
    at ClientRequest.emit (events.js:211:7)
    at HTTPParser.parserOnIncomingClient [as onIncoming] (_http_client.js:551:21)
    at HTTPParser.parserOnHeadersComplete (_http_common.js:117:23)
    at TLSSocket.socketOnData (_http_client.js:440:20)
    at emitOne (events.js:116:13)
    at TLSSocket.emit (events.js:211:7)
    at addChunk (_stream_readable.js:263:12)'
}