### PR TITLE
Parse unknown and no-value tags

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -65,7 +65,6 @@ const parser = (buf) => {
         val;
 
     // http://tools.ietf.org/html/rfc2910#section-3.9
-
     switch (tag) {
       case tags.enum:
         val = read4();
@@ -125,7 +124,10 @@ const parser = (buf) => {
         return readCollection();
       /* eslint-enable no-use-before-define */
 
+      case tags['unknown']:
       case tags['no-value']:
+        return read(0);
+
       default:
         return module.exports.handleUnknownTag(tag, name, length, read);
     }
@@ -298,4 +300,3 @@ module.exports.handleUnknownTag = (tag, name, length, read) => {
 
   throw new Error(`The spec is not clear on how to handle tag ${tag}: ${name}=${String(value)}. Please open a github issue to help find a solution!`);
 };
-

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -124,7 +124,7 @@ const parser = (buf) => {
         return readCollection();
       /* eslint-enable no-use-before-define */
 
-      case tags['unknown']:
+      case tags.unknown:
       case tags['no-value']:
         return read(0);
 


### PR DESCRIPTION
To support responses from CUPS we need to support `unknown` and `no-value` tags.
For example for  printer-dns-sd-name and printer-geo-location.
