### PR TITLE
Support basic auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,23 @@ ipp.request(uri, data, function(err, res) {
 //  ta-da!.. hopefully you'll see a ton of stuff from your printer
 ```
 
+## Basic Auth
+
+If you have to connect to an IPP printer or server that requires Basic Authentication you can add `auth` to the options.
+
+```javascript
+const ipp = require('@sealsystems/ipp');
+const uri = 'your_printer';
+const opts = parseurl(uri);
+opts.auth = 'admin:secr3t';
+ipp.request(opts, data, function(err, res) {
+  if (err) {
+    return console.log(err);
+  }
+  console.log(JSON.stringify(res, null, 2));
+});
+```
+
 ## License
 
 MIT

--- a/lib/printer.js
+++ b/lib/printer.js
@@ -22,6 +22,7 @@ function Printer (url, opts) {
   this.uri = opts.uri || `ipp://${this.url.host}${this.url.path}`;
   this.charset = opts.charset || 'utf-8';
   this.language = opts.language || 'en-us';
+  this.url.auth = opts.auth;
 }
 
 Printer.prototype = {


### PR DESCRIPTION
To test against a CUPS you often need Basic Auth. This PR adds support to add the basic `auth` option to the internal HTTP request.
