### PR TITLE
fix: Fix parsing nameWithLanguage and textWithLanguage tags.

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -97,7 +97,7 @@ const parser = (buf) => {
 
       case tags.textWithLanguage:
       case tags.nameWithLanguage:
-        lang = read(read2());
+        lang = read(length);
         subval = read(read2());
 
         return lang + RS + subval;


### PR DESCRIPTION
Hey @seal-mt 👋 
Hey @seal-mis 👋 

@yeldiRium and I have found a bug in the parser: In the beginning of the `readValue` function the first two bytes are already read as `length`, which is then taken into account when parsing further bytes.

Unfortunately, this was implemented in a wrong way for `nameWithLanguage` and `textWithLanguage` tags, where the next two bytes were parsed *again* (which of course resulted in garbage).

We have fixed this 😊 

If you are fine with this, we would be happy if you could squash / merge this, and release a new version of this module!