### PR TITLE
Ignore unknown tags in parser instead of throwing.

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -151,7 +151,6 @@ const parser = (buf) => {
         return read(0);
 
       default:
-        return;
     }
   };
 

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -151,7 +151,7 @@ const parser = (buf) => {
         return read(0);
 
       default:
-        return module.exports.handleUnknownTag(tag, name, length, read);
+        return;
     }
   };
 
@@ -313,13 +313,3 @@ const parser = (buf) => {
 };
 
 module.exports = parser;
-
-module.exports.handleUnknownTag = (tag, name, length, read) => {
-  const value = length ? read(length) : undefined;
-
-  throw new Error(
-    `The spec is not clear on how to handle tag ${tag}: ${name}=${String(
-      value
-    )}. Please open a github issue to help find a solution!`
-  );
-};


### PR DESCRIPTION
Hey @seal-mis
Hey @seal-mt

In line with the discussion that unknown things in the parser and writer should be ignored instead of throw exceptions, we (i.e. @goloroden and I) removed the `handleUnknownTag` function, so that any values not implemented will be silently ignored.

Could you please review our changes, and squash / merge them if you are fine with them?